### PR TITLE
SRD

### DIFF
--- a/Js/SRD.Type.js
+++ b/Js/SRD.Type.js
@@ -22,6 +22,7 @@
 			Boolean: "boolean",
 			Number: "number",
 			String: "string",
+			StringObject: 'string object',
 			Function: "function",
 			Array: "array",
 			Object: "object",
@@ -34,14 +35,15 @@
 
 	function typeOf(obj)
 	{
-		var result;
-		if(typeof(obj) === TypesNames.Undefined)
+		var result = typeof(obj);
+
+                if(obj instanceof String)
+                {
+                      result = TypesNames.StringObject;
+                }
+		else if(result !== TypesNames.Undefined)
 		{
-			result = TypesNames.Undefined;
-		}
-		else
-		{
-			result = Object.prototype.toString.call(obj).match(/\s([^\]]*)/)[One].toLowerCase();
+			result = Object.prototype.toString.call(obj).match(/\s([^\]]*)/)[1].toLowerCase();
 		}
 
 		return result;


### PR DESCRIPTION
1. Separated two different types:
   - 'string' - native JS string
   - 'string object' - boxed native JS string (new String('A some string.');
     Use cases:
     var strAsStr = 'The string as string',
         strAsObj = new String('The string as object');
     
     // If required granulated string detection
     if(typeOf(strAsStr) === 'string')
     {
       // Will be executed only for the native string.
     }
     
     if(typeOf(strAsObj) === 'string object')
     {
       // Will be executed only for the boxed native string.
     }
     
     // If required abstract 'string' type detection
     if(typeOf(strAsStr).indexOf('string') > -1)
     {
       // Will be executed when no matter is it a native string or a boxed native string.
     }
     
     if(typeOf(strAsObj).indexOf('string') > -1)
     {
       // Will be executed when no matter is it a native string or a boxed native string.
     }
