### PR TITLE
Function names support added

### DIFF
--- a/Examples/SRD.Type.Examples.htm
+++ b/Examples/SRD.Type.Examples.htm
@@ -15,22 +15,24 @@
 		
 			window.addEventListener('load', function()
 			{
-				writeLine('typeOf() ===' + typeOf());
-				writeLine('typeOf(true) ===' + typeOf(true));
-				writeLine('typeOf(1) ===' + typeOf(1));
-				writeLine('typeOf("This is a string.") ===' + typeOf('This is a string.'));
-				writeLine('typeOf(new String("This is a string.")) ===' + typeOf(new String('This is a string.')));
-				writeLine('typeOf(function(){return true;}) ===' + typeOf(function(){return true}));
-				writeLine('typeOf([]) ===' + typeOf([]));
-				writeLine('typeOf({}) ===' + typeOf({}));
-				writeLine('typeOf(window) ===' + typeOf(window));
-				writeLine('typeOf(window.document) ===' + typeOf(window.document));
-				writeLine('typeOf(window.document.body) ===' + typeOf(window.document.body));
-				writeLine('typeOf(Math) ===' + typeOf(Math));
-				writeLine('typeOf(NaN) ===' + typeOf(NaN));
-				writeLine('typeOf(("Test").substr) ===' + typeOf(("Test").substr));
-				writeLine('typeOf(("Test").substr) ===' + typeOf(("Test").substr));
-				writeLine('typeOf(window.document.getElementById("console")) ===' + typeOf(window.document.getElementById("console")));
+				writeLine('typeOf() === \'' + typeOf() + '\'');
+				writeLine('typeOf(true) === \'' + typeOf(true) + '\'');
+				writeLine('typeOf(1) === \'' + typeOf(1) + '\'');
+				writeLine('typeOf("This is a string.") === \'' + typeOf('This is a string.') + '\'');
+				writeLine('typeOf(new String("This is a string.")) === \'' + typeOf(new String('This is a string.')) + '\'');
+				writeLine('typeOf(function(){return true;}) === \'' + typeOf(function(){return true}) + '\'');
+				writeLine('typeOf([]) === \'' + typeOf([]) + '\'');
+				writeLine('typeOf({}) === \'' + typeOf({}) + '\'');
+				writeLine('typeOf(/\s+/) === \'' + typeOf(/\s+/) + '\'');
+				writeLine('typeOf(new RegExp(\'\w+\')) === \'' + typeOf(new RegExp('\w+')) + '\'');
+				writeLine('typeOf(window) === \'' + typeOf(window) + '\'');
+				writeLine('typeOf(window.document) === \'' + typeOf(window.document) + '\'');
+				writeLine('typeOf(window.document.body) === \'' + typeOf(window.document.body) + '\'');
+				writeLine('typeOf(Math) === \'' + typeOf(Math) + '\'');
+				writeLine('typeOf(NaN) === \'' + typeOf(NaN) + '\'');
+				writeLine('typeOf(("Test").substr) === \'' + typeOf(("Test").substr) + '\'');
+				writeLine('typeOf((new String ("Test")).substr) === \'' + typeOf((new String("Test")).substr) + '\'');
+				writeLine('typeOf(window.document.getElementById("console")) === \'' + typeOf(window.document.getElementById("console")) + '\'');
 			}, false);
 		</script>
 	<head>

--- a/Js/SRD.Type.js
+++ b/Js/SRD.Type.js
@@ -14,7 +14,7 @@
 +======================================================================================================================+
 */
 
-(function(context, isExportToContext)
+(function(mountPoint, context)
 {
 	var 	TypesNames = 
 		{
@@ -27,32 +27,58 @@
 			Array: "array",
 			Object: "object",
 		},
+		Zero = 0,
 		One = 1,
-		DefaultIsExportToContext = true,
-		_context = context || this,
-		_isExportToContext = isExportToContext || DefaultIsExportToContext;
+		CharacterSpace = ' ',
+		AnonymousFunctionName = 'anonymous',
+		DefaultEvaluatorPredicateValue = true,
+		_mountPoint = mountPoint;
 
+	var evaluators = 
+	[
+		{ predicate: function(obj) { return obj instanceof String; }, evaluate: function (obj) { return TypesNames.StringObject; } },
+		{ predicate: function(obj) { return obj instanceof Function; }, evaluate: function(obj)
+			{
+				var result = CharacterSpace + AnonymousFunctionName, 
+					matches = Function.prototype.toString.call(obj).match(/function\s+([^\s\{\(]+)/);
+
+				if(!!matches && matches.length > Zero)
+				{
+					result = CharacterSpace + matches[One];
+				}
+
+				result = TypesNames.Function + result;
+
+				return result;
+			} },
+		{ predicate: function(obj) { return typeof obj !== TypesNames.Undefined }, evaluate: function(obj) 
+			{
+				var result = Object.prototype.toString.call(obj).match(/\s([^\]]*)/)[1].toLowerCase(); 
+				return result;
+			} },
+		{ predicate: function(obj) { return DefaultEvaluatorPredicateValue; }, evaluate: function(obj) { return typeof(obj); } }
+	]
 
 	function typeOf(obj)
 	{
-		var result = typeof(obj);
+		var result;
 
-                if(obj instanceof String)
-                {
-                      result = TypesNames.StringObject;
-                }
-		else if(result !== TypesNames.Undefined)
+		for(var index = Zero; index < evaluators.length; index++)
 		{
-			result = Object.prototype.toString.call(obj).match(/\s([^\]]*)/)[1].toLowerCase();
+			if(evaluators[index].predicate(obj))
+			{
+				result = evaluators[index].evaluate(obj);
+				break;
+			}
 		}
 
 		return result;
 	}
 
-	if(_isExportToContext)
+	if(!!_mountPoint)
 	{
-		_context.TypesNames = TypesNames;
-		_context.typeOf = typeOf;
+		_mountPoint.TypesNames = TypesNames;
+		_mountPoint.typeOf = typeOf;
 	}
 
-})();                        
+})(this);                        


### PR DESCRIPTION
1. Function:
   - if name exists return 'function %name%'
     - otherwise return 'function anonymous'
   - Long 'if' with many 'else if' replaced with a collection of evaluators with next methods:
   - boolean predicate(obj)
   - string evaluate(obj)
   - Examples/SRD.Type.Examples.htm:
   - RegExp exa01. Function:mple added
   - Markup fixed
